### PR TITLE
Fix deprecation warning, update stellar SDK

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,8 +5,6 @@ const chalk = require("chalk");
 const cmd = require("command-line-args");
 const readlineSync = require("readline-sync");
 
-StellarSdk.Network.useTestNetwork();
-
 const opts = cmd([
   { name: "client-seed", type: String },
   { name: "issuer-seed", type: String },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "command-line-args": "^5.1.1",
     "node-fetch": "^2.6.0",
     "readline-sync": "^1.4.10",
-    "stellar-sdk": "^2.3.0"
+    "stellar-sdk": "^3.3.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -279,10 +279,10 @@ sodium-native@^2.3.0:
     nan "^2.14.0"
     node-gyp-build "^4.1.0"
 
-stellar-base@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/stellar-base/-/stellar-base-1.1.2.tgz#7b08031f4a5cf4e95b8137472f367903a225ac3d"
-  integrity sha512-dBifZ2NPeOVtHl7pCaSCfvOedUGhKs3qIfqc/ajk9vsOFnHma0sBxb268kQhGWEAUS5tUKYei2ur4dQtB3rDSA==
+stellar-base@^2.1.2:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/stellar-base/-/stellar-base-2.1.3.tgz#6b86b9d07204fb70f974e0092803b16604ac02c9"
+  integrity sha512-ouO9f7cqqQTPEaXA2QZCeWg0EUxgTOJyhmwVhJym3yi1S8/xCSVllIZyLgDH2rORGdiPx3syEgIhBVP1qCAXJQ==
   dependencies:
     base32.js "^0.1.0"
     bignumber.js "^4.0.0"
@@ -294,10 +294,10 @@ stellar-base@^1.1.1:
   optionalDependencies:
     sodium-native "^2.3.0"
 
-stellar-sdk@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/stellar-sdk/-/stellar-sdk-2.3.0.tgz#f1c9005912c7c95d74e15fe1f7bd4f9c09841acd"
-  integrity sha512-iaeV8K98kuqgm1KH8dDitTp6qfpBb0XDZDnAVxCBCW9vs7AOnKadJbIKBtvVhuFXob4uRLvA3hfLJAAEjEzDcw==
+stellar-sdk@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/stellar-sdk/-/stellar-sdk-3.3.0.tgz#829fcf9be82dddfc153c35b066fe09c8d93ddea3"
+  integrity sha512-RCVjuI+SfAhExUOpKbn4i7aNvydRZaIQve25wYr5YTWIiL9ULsEY7puG92CNA7u7PLwo94lLwaHeRwRuMSVtSw==
   dependencies:
     "@types/eventsource" "^1.1.2"
     "@types/node" ">= 8"
@@ -310,7 +310,7 @@ stellar-sdk@^2.3.0:
     eventsource "^1.0.7"
     lodash "^4.17.11"
     randombytes "^2.1.0"
-    stellar-base "^1.1.1"
+    stellar-base "^2.1.2"
     toml "^2.3.0"
     tslib "^1.10.0"
     urijs "^1.19.1"


### PR DESCRIPTION
This is already correctly referencing the testnet when building the transaction, so all that's needed is to remove the global Network reference.

[Here](https://github.com/msfeldstein/create-stellar-token/blob/85eb5fecdb7a716551d5d878f8c33badc17694e9/index.js#L77) and [here](https://github.com/msfeldstein/create-stellar-token/blob/85eb5fecdb7a716551d5d878f8c33badc17694e9/index.js#L106) are where the code is already following the recommendation.